### PR TITLE
hotfix : auth.filter.exclusions 기본값 안들어가는 현상 수정

### DIFF
--- a/src/main/java/online/partyrun/springsecurityauthorizationmanager/SecurityBeanConfig.java
+++ b/src/main/java/online/partyrun/springsecurityauthorizationmanager/SecurityBeanConfig.java
@@ -21,7 +21,7 @@ public class SecurityBeanConfig {
     JwtExtractor extractor;
 
     public SecurityBeanConfig(
-            @Value("${auth.filter.exclusions#{{}}") List<String> exclusions,
+            @Value("${auth.filter.exclusions:#{{}}") List<String> exclusions,
             JwtExtractor extractor) {
         this.exclusions = exclusions;
         this.extractor = extractor;


### PR DESCRIPTION
- 변경점
auth.filter.exclusions 기본값 안들어가는 현상 수정하기 위해 클론 첨부
<!-- - 사유(Option) -->

- 테스트 방식